### PR TITLE
`-d www` option of http-server in my last PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Clone this repository, run `npm install`.
 
 Run `npm start` to run the server. This command uses `nodemon` to automatically restart the server for you, everytime the code is changed.
 
-Run a local webserver in the www directory and open the monitoring application. You may use `npx http-server -d www`, but there are many other options.
+Run a local webserver in the www directory and open the monitoring application. You may use `npx http-server`, but there are many other options.
 
 There is code running every 2 seconds that will broad cast basic stats to the web app:
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "main.js",
   "scripts": {
     "start": "nodemon main.js",
+    "http-server": "cd www && http-server",
     "test": "mocha"
   },
   "author": "",


### PR DESCRIPTION
`-d www` doesn't seem to start the server in www directory, so I changed the command in readme. Additionally there is a `npm run http-server` that can be used.